### PR TITLE
Add quotes to numeric answers

### DIFF
--- a/data/linux_01.yaml
+++ b/data/linux_01.yaml
@@ -47,11 +47,11 @@ questions:
 
   - text: Jaký je standardní port pro SSH (Secure Shell) v Linuxu?
     options:
-      - answer: 21
+      - answer: "21"
         correct: false
-      - answer: 22
+      - answer: "22"
         correct: true
-      - answer: 23
+      - answer: "23"
         correct: false
-      - answer: 80
+      - answer: "80"
         correct: false


### PR DESCRIPTION
I was unable to run the quiz when numbers were not quoted, because they were interpreted as numbers and violated expected format somewhere.